### PR TITLE
Removed axios-middleware, using interceptors, modified unit tests [...]

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,8 @@
 # Description
 This module is an axios third-party module to log any axios request as a curl command in the console. It was originally posted as a suggestion on the axios repository, but since we believed it wasn't in the scope of axios to release such feature, we decided to make it as an independent module.
 
-The module makes use of axios and axios-middleware.
-
-**_Supported axios version as of 2018/06/20 : 0.17.1_**
-
 # How it works
-Basically, we use the axios-middleware to log the curl commands on every request. As simple as that.
+The module makes use of axios' interceptors to log the request as a cURL command. It also stores it in the response's config object. Therefore, the command can be seen in the app's console, as well as in the ```res.config.curlCommand``` property of the response.
 
 # How to use it
 axios-curlirize is super easy to use. First you'll have to install it.
@@ -37,7 +33,7 @@ Then all you have to do is import and instanciate curlirize in your app. Here's 
         console.log('Dummy server started on port 7500')
         /*
              The output of this in the console will be :
-             curl -X POST  -H "Accept:application/json, text/plain" -H "Content-Type:application/json;charset=utf-8" --data "{\"dummy\":\"data\"}" http://localhost:7500/
+             curl -X POST -H "Content-Type:application/x-www-form-urlencoded" --data {"dummy":"data"} http://localhost:7500/http://localhost:7500/
         */
         axios.post('http://localhost:7500/', {dummy: 'data'})
             .then((res) => {

--- a/dist/curlirize.js
+++ b/dist/curlirize.js
@@ -4,18 +4,19 @@ Object.defineProperty(exports, "__esModule", {
     value: true
 });
 
-var _axiosMiddleware = require('axios-middleware');
-
 var _CurlHelper = require('./lib/CurlHelper');
 
-exports.default = function (instance) {
-    var service = new _axiosMiddleware.HttpMiddlewareService(instance);
+var _fancyLog = require('fancy-log');
 
-    service.register({
-        onRequest: function onRequest(config) {
-            var curl = new _CurlHelper.CurlHelper(config);
-            console.log(curl.generateCommand());
-            return config;
-        }
+var _fancyLog2 = _interopRequireDefault(_fancyLog);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+exports.default = function (instance) {
+    instance.interceptors.request.use(function (req) {
+        var curl = new _CurlHelper.CurlHelper(req);
+        req.curlCommand = curl.generateCommand();
+        _fancyLog2.default.info(req.curlCommand);
+        return req;
     });
 };

--- a/dist/lib/AxiosMiddleware.js
+++ b/dist/lib/AxiosMiddleware.js
@@ -1,0 +1,1 @@
+"use strict";

--- a/dist/lib/CurlHelper.js
+++ b/dist/lib/CurlHelper.js
@@ -23,11 +23,17 @@ var CurlHelper = exports.CurlHelper = function () {
             var headers = this.request.headers;
             var curlHeaders = '';
 
-            for (var property in headers) {
-                curlHeaders = curlHeaders + ' -H "' + property + ':' + headers[property] + '"';
+            //get the headers concerning the appropriate method
+            if (headers.hasOwnProperty('common')) {
+                headers = this.request.headers[this.request.method];
             }
 
-            return curlHeaders;
+            for (var property in headers) {
+                var header = property + ':' + headers[property];
+                curlHeaders = curlHeaders + ' -H "' + header + '"';
+            }
+
+            return curlHeaders.trim();
         }
     }, {
         key: 'getMethod',
@@ -38,17 +44,17 @@ var CurlHelper = exports.CurlHelper = function () {
         key: 'getBody',
         value: function getBody() {
             var data = _typeof(this.request.data) === 'object' || typeof this.request.data === 'array' ? JSON.stringify(this.request.data) : this.request.data;
-            return '--data ' + JSON.stringify(this.request.data);
+            return ('--data ' + data).trim();
         }
     }, {
         key: 'getUrl',
         value: function getUrl() {
-            return this.request.url;
+            return this.request.url.trim();
         }
     }, {
         key: 'generateCommand',
         value: function generateCommand() {
-            return 'curl ' + this.getMethod() + ' ' + this.getHeaders() + ' ' + this.getBody() + ' ' + this.getUrl();
+            return ('curl ' + this.getMethod() + ' ' + this.getHeaders() + ' ' + this.getBody() + ' ' + this.getUrl()).trim();
         }
     }]);
 

--- a/dist/test/curlirize.test.js
+++ b/dist/test/curlirize.test.js
@@ -4,10 +4,6 @@ var _expect = require('expect');
 
 var _expect2 = _interopRequireDefault(_expect);
 
-var _supertest = require('supertest');
-
-var _supertest2 = _interopRequireDefault(_supertest);
-
 var _axios = require('axios');
 
 var _axios2 = _interopRequireDefault(_axios);
@@ -28,16 +24,21 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 
 (0, _curlirize2.default)(_axios2.default);
 
-describe('Testing axios-middleware module', function () {
+describe('Testing curlirize', function () {
     it('should return a 200 with the value \'world\'', function (done) {
-        var headers = {
-            SomeHeader: 'someValue',
-            RandomThing: 'dummyVal'
-        };
-
-        _axios2.default.post('http://localhost:7500/', { dummy: 'data' }, {}).then(function (res) {
+        _axios2.default.post('http://localhost:7500/', { dummy: 'data' }).then(function (res) {
             (0, _expect2.default)(res.status).toBe(200);
             (0, _expect2.default)(res.data.hello).toBe('world');
+            done();
+        }).catch(function (err) {
+            _fancyLog2.default.error(err);
+        });
+    });
+
+    it('should return the response with the defined curl command', function (done) {
+        _axios2.default.post('http://localhost:7500/', { dummy: 'data' }).then(function (res) {
+            (0, _expect2.default)(res.config.curlCommand).toBeDefined();
+            (0, _expect2.default)(res.config.curlCommand).toBe('curl -X POST -H "Content-Type:application/x-www-form-urlencoded" --data {"dummy":"data"} http://localhost:7500/');
             done();
         }).catch(function (err) {
             _fancyLog2.default.error(err);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "axios-curlirize",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -103,18 +103,14 @@
       "optional": true
     },
     "axios": {
-      "version": "0.17.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.17.1.tgz",
-      "integrity": "sha1-LY4+XQvb1zJ/kbyBT1xXZg+Bgk0=",
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
+      "integrity": "sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=",
+      "dev": true,
       "requires": {
         "follow-redirects": "1.5.0",
         "is-buffer": "1.1.6"
       }
-    },
-    "axios-middleware": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/axios-middleware/-/axios-middleware-0.2.0.tgz",
-      "integrity": "sha512-b5Kx3PqcLn0uCKE1YKUZUH5QmSc230n/0XSN3IcUTuNabqxCiIDJMmZxAo1NW/oWudygXHALNHHacN764kHEjw=="
     },
     "babel-cli": {
       "version": "6.26.0",
@@ -952,6 +948,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
       "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "dev": true,
       "requires": {
         "ms": "2.0.0"
       }
@@ -1177,6 +1174,7 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.0.tgz",
       "integrity": "sha512-fdrt472/9qQ6Kgjvb935ig6vJCuofpBUD14f9Vb+SLlm7xIe4Qva5gey8EKtv8lp7ahE1wilg3xL1znpVGtZIA==",
+      "dev": true,
       "requires": {
         "debug": "3.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -22,8 +22,6 @@
   },
   "homepage": "https://github.com/augmnt/axios-curlirize#readme",
   "dependencies": {
-    "axios": "^0.17.1",
-    "axios-middleware": "^0.2.0",
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.0",
     "babel-polyfill": "^6.26.0",
@@ -31,6 +29,7 @@
     "fancy-log": "^1.3.2"
   },
   "devDependencies": {
+    "axios": "^0.18.0",
     "expect": "^23.1.0",
     "express": "^4.16.3",
     "mocha": "^5.2.0"

--- a/src/curlirize.js
+++ b/src/curlirize.js
@@ -1,18 +1,11 @@
-import { HttpMiddlewareService } from 'axios-middleware';
 import { CurlHelper } from './lib/CurlHelper';
 import logger from 'fancy-log';
 
 export default (instance) => {
-    const service = new HttpMiddlewareService(instance);
-
-    service.register({
-        onRequest(config) {
-            //log curl command
-            let curl = new CurlHelper(config);
-            logger.info(curl.generateCommand());
-
-            //handle axios request as usual
-            return config;
-        }
-    })
+    instance.interceptors.request.use(req => {
+        let curl = new CurlHelper(req);
+        req.curlCommand = curl.generateCommand();
+        logger.info(req.curlCommand);
+        return req;
+    });
 }

--- a/src/lib/CurlHelper.js
+++ b/src/lib/CurlHelper.js
@@ -4,14 +4,20 @@ export class CurlHelper {
     }
 
     getHeaders() {
-        const headers = this.request.headers;
+        let headers = this.request.headers;
         let curlHeaders = '';
+
+        //get the headers concerning the appropriate method
+        if(headers.hasOwnProperty('common')) {
+            headers = this.request.headers[this.request.method];
+        }
         
         for(let property in headers) {
-            curlHeaders = `${curlHeaders} -H "${property}:${headers[property]}"`
+            let header = `${property}:${headers[property]}`;
+            curlHeaders = `${curlHeaders} -H "${header}"`
         }
 
-        return curlHeaders;
+        return curlHeaders.trim();
     }
 
     getMethod() {
@@ -20,15 +26,15 @@ export class CurlHelper {
 
     getBody() {
         let data = (typeof this.request.data === 'object' || typeof this.request.data === 'array') ? JSON.stringify(this.request.data) : this.request.data;
-        return `--data ${JSON.stringify(this.request.data)}`;
+        return `--data ${data}`.trim();
         
     }
 
     getUrl() {
-        return this.request.url;
+        return this.request.url.trim();
     }
 
     generateCommand() {
-        return `curl ${this.getMethod()} ${this.getHeaders()} ${this.getBody()} ${this.getUrl()}`;
+        return `curl ${this.getMethod()} ${this.getHeaders()} ${this.getBody()} ${this.getUrl()}`.trim();
     }
 }

--- a/src/test/curlirize.test.js
+++ b/src/test/curlirize.test.js
@@ -52,22 +52,22 @@ describe('Testing curl-helper module', () => {
     const curl = new CurlHelper(fakeConfig);
 
     it('should return a string with headers', (done) => {
-        expect(curl.getHeaders().trim()).toBe('-H "Accept:application/json, text/plain, */*" -H "Content-Type:application/json;charset=utf-8"');
+        expect(curl.getHeaders()).toBe('-H "Accept:application/json, text/plain, */*" -H "Content-Type:application/json;charset=utf-8"');
         done();
     });
 
     it('should return a string with HTTP method', (done) => {
-        expect(curl.getMethod().trim()).toBe('-X POST');
+        expect(curl.getMethod()).toBe('-X POST');
         done();
     });
 
     it('should return a string with request body', (done) => {
-        expect(curl.getBody().trim()).toBe('--data {"dummy":"data"}');
+        expect(curl.getBody()).toBe('--data {"dummy":"data"}');
         done();
     });
 
     it('should return the URL of the request', (done) => {
-        expect(curl.getUrl().trim()).toBe("http://localhost:7500/");
+        expect(curl.getUrl()).toBe("http://localhost:7500/");
         done();
     });
 });

--- a/src/test/curlirize.test.js
+++ b/src/test/curlirize.test.js
@@ -8,12 +8,24 @@ import {app} from './devapp';
 
 curlirize(axios);
 
-describe('Testing axios-middleware module', () => {
+describe('Testing curlirize', () => {
     it('should return a 200 with the value \'world\'', (done) => {
-        axios.post('http://localhost:7500/', {dummy: 'data'}, {})
+        axios.post('http://localhost:7500/', {dummy: 'data'})
         .then((res) => {
             expect(res.status).toBe(200);
             expect(res.data.hello).toBe('world');
+            done();
+        })
+        .catch((err) => {
+            logger.error(err);
+        });
+    });
+
+    it('should return the response with the defined curl command', (done) => {
+        axios.post('http://localhost:7500/', {dummy: 'data'})
+        .then((res) => {
+            expect(res.config.curlCommand).toBeDefined();
+            expect(res.config.curlCommand).toBe('curl -X POST -H "Content-Type:application/x-www-form-urlencoded" --data {"dummy":"data"} http://localhost:7500/');
             done();
         })
         .catch((err) => {


### PR DESCRIPTION
* Removed axios-middleware
* Using axios interceptors instead
* Added/modified unit tests
  * Added unit testing for the curlirize module
  * Moved trimming in unit tests directly to the CurlHelper class methods
* Cleaned up the package.json file
  * moved axios to dev dependency
  * removed axios middleware
  * changed version to 0.0.5
* Modified the logic behind CurlHelper's getHeaders() method
* Modified README.md